### PR TITLE
New variant parameters class

### DIFF
--- a/actor.py
+++ b/actor.py
@@ -105,11 +105,14 @@ class Actor:
     # Infect the individual. Starts as EXPOSED.
 
     def infect(self, variant = None):
+        self.myInfection = Infection(self, variant = variant)
+        if variant is None:
+            variant = self.myInfection.variant
+
         self.infectedTime = 0
         self.status = ACTOR_STATUS.EXPOSED
-        self.isAsymptomatic = random.random() < self.simulationParameters.asymptomaticRate
-        self.willSelfIsolate = random.random() < self.simulationParameters.selfIsolationRate
-        self.myInfection = Infection(self, variant = variant)
+        self.isAsymptomatic = random.random() < self.simulationParameters.variantParameters[variant].asymptomaticRate
+        self.willSelfIsolate = random.random() < self.simulationParameters.variantParameters[variant].selfIsolationRate
 
     def vaccinate(self):
         self.isVaccinated = True
@@ -175,7 +178,7 @@ class Actor:
 
             elif (self.status == ACTOR_STATUS.INFECTIOUS):
                 if (not self.myInfection.isContagious()):
-                    if (random.random() < self.simulationParameters.mortalityRate):
+                    if (random.random() < self.simulationParameters.variantParameters[self.myInfection.variant].mortalityRate):
                         self.status = ACTOR_STATUS.DECEASED
                     else:
                         self.status = ACTOR_STATUS.RECOVERED

--- a/infection.py
+++ b/infection.py
@@ -14,23 +14,23 @@ class Infection:
 
         # Number of days infected
         self.infectedTime = 0
-
-        # TODO: Sample these values in the future!
-        params = self.myActor.simulationParameters
         
         # Assign variant
         if variant is not None:
             self.variant = variant
         else:
             rnd = random.random()
-            for v, pct in params.startingVariantMix.items():
+            for v, pct in self.myActor.simulationParameters.startingVariantMix.items():
                 rnd -= pct
                 if rnd <= 0:
                     self.variant = v
                     break
 
+        # TODO: Sample these values in the future!
+        params = self.myActor.simulationParameters.variantParameters[self.variant]
+
         # Whether this infection will be asymptomatic. Sampled for this actor.
-        self.asymptomatic = (random.random() < self.myActor.simulationParameters.asymptomaticRate)
+        self.asymptomatic = (random.random() < params.asymptomaticRate)
         # The days until contagious. Sampled for this actor.
         self.daysToContagious = gaussianRandom(params.daysToContagious, params.daysToContagiousSTD)
         self.daysToNotContagious = self.daysToContagious + gaussianRandom(

--- a/simulation.py
+++ b/simulation.py
@@ -105,6 +105,15 @@ class SimulationParameters :
     daysToDetectable = 2.5
     daysToDetectableSTD = 0.5
 
+    def __init__(self):
+        # Create a dictionary of variant parameters
+        for v in self.startingVariantMix:
+            self.variantParameters[v] = VariantParameters(v)
+            
+        # Customize the parameters for the different variants
+        self.variantParameters['alpha'].transmissionRate /= 2
+        self.variantParameters['omicron'].transmissionRate *= 2
+
 
 class VariantParameters :
 
@@ -188,8 +197,6 @@ class Simulation:
         self.totals = RunStatistics()
         self.daysElapsed = 0
 
-        self.setupVariantParameters()
-        
         rows = math.floor(math.sqrt(self.simulationParameters.populationSize))
         for i in range(self.simulationParameters.populationSize):
             a = Actor(self)
@@ -211,15 +218,6 @@ class Simulation:
         # The remaining susceptible, after we've created the initially infected
         self.totals.susceptible = self.simulationParameters.populationSize - self.totals.infected
         
-    def setupVariantParameters(self):
-        # Create a dictionary of variant parameters
-        for v in self.simulationParameters.startingVariantMix:
-            self.simulationParameters.variantParameters[v] = VariantParameters(v)
-            
-        # Customize the parameters for the different variants
-        self.simulationParameters.variantParameters['alpha'].transmissionRate /= 2
-        self.simulationParameters.variantParameters['omicron'].transmissionRate *= 2
-
     # *
     # Models transmission from an infected individual to a susceptible
     # individual.


### PR DESCRIPTION
I created a new class `VariantParameters` and moved the params that I thought could differ by variant into this new class.  Default values are set here.
`SimulationParameters` now has a dict `variantParameters` with one entry per variant.
Modified places where parameters are accessed to use the new variant parameters.