### PR TITLE
Changed Infection to keep reference to VariantParameters instance

### DIFF
--- a/actor.py
+++ b/actor.py
@@ -14,7 +14,6 @@ class ACTOR_STATUS (Enum):
     DECEASED=    4
 
 # Protection is 1.0 for no protection, 0 for full protection
-@dataclass
 class ACTOR_PROTECTION:
     NONE= 1.0
     MASK= 0.1
@@ -88,7 +87,9 @@ class Actor:
         self.isVaccinated = False
 
         # actor has vaccine protection.
-        self.isVaccinatedProtected = False
+        self.isVaccinatedProtected = {}
+        for v in self.simulationParameters.variantParameters:
+            self.isVaccinatedProtected[v] = False
 
         # Whether or not this actor will self-isolate when symptoms appear.
         self.willSelfIsolate = True
@@ -230,5 +231,6 @@ class Actor:
 
             # This can only happen once.
             if (self.vaccinationRemain <= 0):
-                if (random.random() < self.simulationParameters.vaccinationEfficacy):
-                    self.isVaccinatedProtected = True
+                for name, variant in self.simulationParameters.variantParameters.items():
+                    if (random.random() < variant.vaccinationEfficacy):
+                        self.isVaccinatedProtected[name] = True

--- a/actor.py
+++ b/actor.py
@@ -104,15 +104,13 @@ class Actor:
 
     # Infect the individual. Starts as EXPOSED.
 
-    def infect(self, variant = None):
-        self.myInfection = Infection(self, variant = variant)
-        if variant is None:
-            variant = self.myInfection.variant
+    def infect(self, variant):
+        self.myInfection = Infection(self, variant)
 
         self.infectedTime = 0
         self.status = ACTOR_STATUS.EXPOSED
-        self.isAsymptomatic = random.random() < self.simulationParameters.variantParameters[variant].asymptomaticRate
-        self.willSelfIsolate = random.random() < self.simulationParameters.variantParameters[variant].selfIsolationRate
+        self.isAsymptomatic = random.random() < variant.asymptomaticRate
+        self.willSelfIsolate = random.random() < variant.selfIsolationRate
 
     def vaccinate(self):
         self.isVaccinated = True
@@ -178,7 +176,7 @@ class Actor:
 
             elif (self.status == ACTOR_STATUS.INFECTIOUS):
                 if (not self.myInfection.isContagious()):
-                    if (random.random() < self.simulationParameters.variantParameters[self.myInfection.variant].mortalityRate):
+                    if (random.random() < self.myInfection.variant.mortalityRate):
                         self.status = ACTOR_STATUS.DECEASED
                     else:
                         self.status = ACTOR_STATUS.RECOVERED

--- a/actor.py
+++ b/actor.py
@@ -19,6 +19,14 @@ class ACTOR_PROTECTION:
     NONE= 1.0
     MASK= 0.1
 
+@dataclass
+class InfectionRecord:
+# Small record to log past infection(s)
+    from_id: int
+    to_id: int
+    variant_name: str
+    time: int
+
 class Actor:
 
     def __init__(self, simulation):
@@ -105,16 +113,22 @@ class Actor:
 
         # currently active infection
         self.myInfection = None
+        
+        # list of infections
+        self.infections = []
 
     # Infect the individual. Starts as EXPOSED.
 
-    def infect(self, variant):
+    def infect(self, variant, exposer_id):
         self.myInfection = Infection(self, variant)
 
         self.infectedTime = 0
         self.status = ACTOR_STATUS.EXPOSED
         self.isAsymptomatic = random.random() < variant.asymptomaticRate
         self.willSelfIsolate = random.random() < variant.selfIsolationRate
+        
+        # Log infection record
+        self.infections.append(InfectionRecord(exposer_id, self.id, variant.name, self.simulation.simClock))
 
     def vaccinate(self):
         self.isVaccinated = True

--- a/infection.py
+++ b/infection.py
@@ -4,7 +4,7 @@ from util import gaussianRandom
 
 class Infection:
 
-    def __init__(self, actor, variant = None):
+    def __init__(self, actor, variant):
         # The actor who is infected
         self.myActor = actor
 
@@ -16,39 +16,30 @@ class Infection:
         self.infectedTime = 0
         
         # Assign variant
-        if variant is not None:
-            self.variant = variant
-        else:
-            rnd = random.random()
-            for v, pct in self.myActor.simulationParameters.startingVariantMix.items():
-                rnd -= pct
-                if rnd <= 0:
-                    self.variant = v
-                    break
+        self.variant = variant
 
         # TODO: Sample these values in the future!
-        params = self.myActor.simulationParameters.variantParameters[self.variant]
 
         # Whether this infection will be asymptomatic. Sampled for this actor.
-        self.asymptomatic = (random.random() < params.asymptomaticRate)
+        self.asymptomatic = (random.random() < variant.asymptomaticRate)
         # The days until contagious. Sampled for this actor.
-        self.daysToContagious = gaussianRandom(params.daysToContagious, params.daysToContagiousSTD)
+        self.daysToContagious = gaussianRandom(variant.daysToContagious, variant.daysToContagiousSTD)
         self.daysToNotContagious = self.daysToContagious + gaussianRandom(
-            params.daysToRecovery - params.daysToContagious, params.daysToRecoverySTD)
+            variant.daysToRecovery - variant.daysToContagious, variant.daysToRecoverySTD)
         # If symptomatic, the days until symptomatic. Sampled for this actor.
-        self.daysToSymptomatic = gaussianRandom(params.daysToSymptoms, params.daysToSymptomsSTD)
-        self.daysToNotSymptomatic = self.daysToSymptomatic + gaussianRandom(params.daysToRecovery,
-                                                                            params.daysToRecoverySTD)
+        self.daysToSymptomatic = gaussianRandom(variant.daysToSymptoms, variant.daysToSymptomsSTD)
+        self.daysToNotSymptomatic = self.daysToSymptomatic + gaussianRandom(variant.daysToRecovery,
+                                                                            variant.daysToRecoverySTD)
         # days_to_pcr detectable. Sampled for this actor.
-        self.daysToPcrDetectable = gaussianRandom(params.daysToPcrDetectable, params.daysToPcrDetectableSTD)
-        self.daysToPcrNotDetectable = self.daysToPcrDetectable + gaussianRandom(params.durationDaysOfPcrDetection,
-                                                                                params.durationDaysOfPcrDetectionSTD)
+        self.daysToPcrDetectable = gaussianRandom(variant.daysToPcrDetectable, variant.daysToPcrDetectableSTD)
+        self.daysToPcrNotDetectable = self.daysToPcrDetectable + gaussianRandom(variant.durationDaysOfPcrDetection,
+                                                                                variant.durationDaysOfPcrDetectionSTD)
         # days until the rapid test will detect. Sampled for this actor.
         # this assures that the sampled daysToAntigenDetectible is after the sampled daysToPcrDetectible
         self.daysToAntigenDetectable = self.daysToPcrDetectable + gaussianRandom(
-            params.daysToAntigenDetectable - params.daysToPcrDetectable, params.daysToAntigenDetectableSTD)
+            variant.daysToAntigenDetectable - variant.daysToPcrDetectable, variant.daysToAntigenDetectableSTD)
         self.daysToAntigenNotDetectable = self.daysToAntigenDetectable + gaussianRandom(
-            params.durationDaysOfAntigenDetection, params.durationDaysOfAntigenDetectionSTD)
+            variant.durationDaysOfAntigenDetection, variant.durationDaysOfAntigenDetectionSTD)
 
     def tick(self, days=1.0):
         self.infectedTime += days

--- a/infection.py
+++ b/infection.py
@@ -41,7 +41,7 @@ class Infection:
         self.daysToAntigenNotDetectable = self.daysToAntigenDetectable + gaussianRandom(
             variant.durationDaysOfAntigenDetection, variant.durationDaysOfAntigenDetectionSTD)
 
-        self.isFatal = (random.random() < params.infectionFatalityRateByAge[self.myActor.ageBracket])
+        self.isFatal = (random.random() < variant.infectionFatalityRateByAge[self.myActor.ageBracket])
 
     def tick(self, days=1.0):
         self.infectedTime += days

--- a/simulation.py
+++ b/simulation.py
@@ -220,7 +220,16 @@ class Simulation:
         for cnt in range(int(max(1,
                                  self.simulationParameters.startingInfectionRate * self.simulationParameters.populationSize))):
             idx = math.floor(random.random() * len(self.actors))
-            self.actors[idx].infect()
+
+            # Choose variants randomly according to starting mix
+            rnd = random.random()
+            for v, pct in self.simulationParameters.startingVariantMix.items():
+                rnd -= pct
+                if rnd <= 0:
+                    variant = self.simulationParameters.variantParameters[v]
+                    break
+            
+            self.actors[idx].infect(variant)
             self.totals.infected += 1
 
         # The remaining susceptible, after we've created the initially infected
@@ -245,7 +254,7 @@ class Simulation:
         if (infected.isolated):
             return False
 
-        if (random.random() < self.simulationParameters.variantParameters[infected.myInfection.variant].transmissionRate
+        if (random.random() < infected.myInfection.variant.transmissionRate
                 * infected.protection
                 * activity
                 * duration / 0.0104

--- a/simulation.py
+++ b/simulation.py
@@ -240,7 +240,7 @@ class Simulation:
                     variant = self.simulationParameters.variantParameters[v]
                     break
             
-            self.actors[idx].infect(variant)
+            self.actors[idx].infect(variant, -1)    # Initial exposures get dummy ID of -1
             self.totals.infected += 1
 
         # The remaining susceptible, after we've created the initially infected
@@ -270,7 +270,6 @@ class Simulation:
                 * activity
                 * duration / 0.0104
         ):
-            susceptible.infect(infected.myInfection.variant)
             return True
 
         return False
@@ -310,14 +309,12 @@ class Simulation:
     def checkExposure(self, actor, other, duration=0.0104, activity=ACTIVITY.NORMAL):
         if (self.hasBeenExposed(other, actor)):
             # print((actor.id, 'infects', other.id)
-            # TODO:  Has the infection already been performed by hasBeenExposed()?
-            other.infect(actor.myInfection.variant)
+            other.infect(actor.myInfection.variant, actor.id)
             return True
 
         if (self.hasBeenExposed(actor, other)):
             # print((other.id, 'infects', actor.id)
-            # TODO:  Has the infection already been performed by hasBeenExposed()?
-            actor.infect(other.myInfection.variant)
+            actor.infect(other.myInfection.variant, other.id)
             return True
 
         return False

--- a/simulation.py
+++ b/simulation.py
@@ -45,9 +45,6 @@ class SimulationParameters :
     # Vaccination delay
     vaccinationDelay = 28
 
-    # Vaccination effectiveness
-    vaccinationEfficacy = 0.95
-
     # Non compliance rate
     # TODO: This parameter is sampled and assigned to actors, but never actively used
     nonCompliantRate = 0.0
@@ -188,16 +185,19 @@ class VariantParameters :
         #  https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7721859/pdf/10654_2020_Article_698.pdf
         self.infectionFatalityRateByAge=[0.00004,0.00004,0.00004,0.00068,0.023,0.0775,0.025,0.085,0.283]
 
+        ###  Vaccination Parameters  ##########################################################
+
+        # Vaccination effectiveness
+        self.vaccinationEfficacy = 0.95
+        
     
 
 # Activity is a risk modifier. 1.0 is normal, 0.0 is safe, >1.0 is risky
-@dataclass
 class ACTIVITY:
     NORMAL= 1.0
     SAFE=   0.1
 
 
-@dataclass
 class RunStatistics:
     susceptible = 0
     infected = 0
@@ -259,7 +259,7 @@ class Simulation:
         ):
             return False
 
-        if (susceptible.isVaccinatedProtected):
+        if (susceptible.isVaccinatedProtected[infected.myInfection.variant.name]):
             return False
 
         if (infected.isolated):


### PR DESCRIPTION
Changed Infection to keep reference to VariantParameters instance instead of the name of the variant
Also made variant required for the infection process, and moved the random variant initialization logic from deep inside the Infection, to up top as part of the simulation initialization.